### PR TITLE
fix: install isomorphic-unfetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "discord-api-types": "^0.37.11",
         "discord-music-player": "^9.1.1",
         "discord.js": "^14.3.0",
+        "isomorphic-unfetch": "^3.1.0",
         "ohmyfetch": "^0.4.19",
         "opusscript": "^0.0.8",
         "quick.db": "^9.0.6",
@@ -1036,6 +1037,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "node_modules/libsodium": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
@@ -1781,6 +1791,11 @@
       "engines": {
         "node": ">=12.18"
       }
+    },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2627,6 +2642,15 @@
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
       "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
     },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "libsodium": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
@@ -3154,6 +3178,11 @@
       "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.10.0.tgz",
       "integrity": "sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g=="
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "discord-api-types": "^0.37.11",
     "discord-music-player": "^9.1.1",
     "discord.js": "^14.3.0",
+    "isomorphic-unfetch": "^3.1.0",
     "ohmyfetch": "^0.4.19",
     "opusscript": "^0.0.8",
     "quick.db": "^9.0.6",


### PR DESCRIPTION
On an empty installation it cannot run because it says

node:internal/modules/cjs/loader:959
  throw err;
  ^

Error: Cannot find module 'isomorphic-unfetch'
Require stack:
- /klabot/node_modules/discord-music-player/dist/utils/Utils.js
- /klabot/node_modules/discord-music-player/dist/index.js
- /klabot/index.js at Function.Module._resolveFilename (node:internal/modules/cjs/loader:956:15) at Function.Module._load (node:internal/modules/cjs/loader:804:27) at Module.require (node:internal/modules/cjs/loader:1028:19) at require (node:internal/modules/cjs/helpers:102:18) at Object.<anonymous> (/klabot/node_modules/discord-music-player/dist/utils/Utils.js:8:46) at Module._compile (node:internal/modules/cjs/loader:1126:14) at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10) at Module.load (node:internal/modules/cjs/loader:1004:32) at Function.Module._load (node:internal/modules/cjs/loader:839:12) at Module.require (node:internal/modules/cjs/loader:1028:19) { code: 'MODULE_NOT_FOUND', requireStack: [ '/klabot/node_modules/discord-music-player/dist/utils/Utils.js', '/klabot/node_modules/discord-music-player/dist/index.js', '/klabot/index.js' ] }

I fix this by adding isomorphic-unfetch as discord-music-player asks.